### PR TITLE
Only use language detection

### DIFF
--- a/src/components/detectText.js
+++ b/src/components/detectText.js
@@ -7,7 +7,7 @@ async function DetectChatText(content) {
             source: {
                 text: content,
             },
-            type: 'all'
+            type: 'language'
         }
     })
     return detectLang


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/amazon-connect-chat-translate/issues/52

*Description of changes:*

Changed Amplify Predictions Interpret to only identify the dominant language, as opposed to entity, sentiment detection, etc so the Amazon Translate functionality can expand to all languages supported by Amazon Translate.

Amazon Comprehend Entity detection is limited to a subset of languages supported compared to it's detect dominant language feature. Using interpret to detect entity, sentiment, etc is unnecessary for this solution and creates exceptions when a language (example Swedish) that doesn't have entity detection support is used. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
